### PR TITLE
Remove unused nose dependency & test_suite from setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,6 @@ setup(
     description='Python library of common utilities for Yubico applications.',
     license='BSD 2 clause',
     packages=find_packages(),
-    setup_requires=['nose>=1.0'],
-    install_requires=[],
-    test_suite='nose.collector',
-    tests_require=[''],
     cmdclass={'release': release},
     classifiers=[
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
There isn't a test suite, and hence nothing to use nose.
