### PR TITLE
Python 3.x fixes

### DIFF
--- a/yubicommon/cli/__init__.py
+++ b/yubicommon/cli/__init__.py
@@ -25,6 +25,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 
 from docopt import docopt, DocoptExit
 import sys
@@ -92,5 +93,5 @@ class CliCommand(object):
                 try:
                     setattr(self, f, value(self._args))
                 except ValueError as e:
-                    print "Error for option {}: {}".format(value._name, e)
+                    print("Error for option {}: {}".format(value._name, e))
                     raise DocoptExit()

--- a/yubicommon/cli/__init__.py
+++ b/yubicommon/cli/__init__.py
@@ -45,14 +45,14 @@ def trim(docstring):
     # and split into a list of lines:
     lines = docstring.expandtabs().splitlines()
     # Determine minimum indentation (first line doesn't count):
-    indent = sys.maxint
+    indent = sys.maxsize
     for line in lines[1:]:
         stripped = line.lstrip()
         if stripped:
             indent = min(indent, len(line) - len(stripped))
     # Remove indentation (first line is special):
     trimmed = [lines[0].strip()]
-    if indent < sys.maxint:
+    if indent < sys.maxsize:
         for line in lines[1:]:
             trimmed.append(line[indent:].rstrip())
     # Strip off trailing and leading blank lines:

--- a/yubicommon/cli/__init__.py
+++ b/yubicommon/cli/__init__.py
@@ -25,10 +25,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
 from __future__ import print_function
 
 from docopt import docopt, DocoptExit
 import sys
+
+from .. import compat
 
 __all__ = ['CliCommand', 'Argument']
 
@@ -68,7 +71,7 @@ class Argument(object):
         self._default = default
 
     def __call__(self, args):
-        if isinstance(self._name, basestring):
+        if isinstance(self._name, compat.string_types):
             value = args[self._name]
         else:
             value = None

--- a/yubicommon/compat.py
+++ b/yubicommon/compat.py
@@ -1,0 +1,18 @@
+"""Compatibility constants and helpers for Python 2.x and 3.x.
+"""
+
+# NB If this module grows to more than a handful of items it is probably
+#    to bite the bullet and depend on the six package.
+__all__ = [
+    'string_types',
+]
+
+# Needed for isinstance() checks
+# Same behaviour as six.string_types https://pythonhosted.org/six/#constants
+try:
+    # Python 2.x
+    string_types = basestring
+except NameError:
+    # Python 3.x
+    string_types = str
+

--- a/yubicommon/qt/classes.py
+++ b/yubicommon/qt/classes.py
@@ -33,6 +33,8 @@ import sys
 import time
 import importlib
 
+from .. import compat
+
 __all__ = ['Application', 'Dialog', 'MutexLocker']
 
 TOP_SECTION = '<b>%s</b>'
@@ -93,7 +95,8 @@ class Application(QtGui.QApplication):
 
         if m:
             for key in dir(m):
-                if isinstance(key, basestring) and not key.startswith('_'):
+                if (isinstance(key, compat.string_types)
+                        and not key.startswith('_')):
                     setattr(m, key, self.tr(getattr(m, key)))
 
         self.worker = Worker(self.window, m)


### PR DESCRIPTION
These changes allow yubicommon to maintain simultaneous Python 2.x and 3.x compatibility. They were found using `2to3`.

Note that https://github.com/Yubico/python-yubicommon/commit/6154e612b9f5916f7fe278633de70ce63c0493f5 creates `yubicommon/compat.py`.
