### PR TITLE
Add text_type, fix definition of string_types

### DIFF
--- a/yubicommon/compat.py
+++ b/yubicommon/compat.py
@@ -8,6 +8,7 @@ import sys
 __all__ = [
     'string_types',
     'binary_type',
+    'text_type',
     'int2byte',
     'byte2int'
 ]
@@ -17,13 +18,15 @@ __all__ = [
 if sys.version_info < (3, 0):
     # Python 2.x
     _PY2 = True
-    string_types = basestring
+    string_types = (basestring,)
     binary_type = str
+    text_type = unicode
 else:
     # Python 3.x
     _PY2 = False
-    string_types = str
+    string_types = (str,)
     binary_type = bytes
+    text_type = str
 
 def int2byte(i):
     if _PY2:


### PR DESCRIPTION
As per https://github.com/Yubico/python-u2flib-server/commit/49930e539deeede13fcc512feaf88bc414080a46#commitcomment-16298462 et al this commit adds `yubicommon.compat.text_type`, mirroring the beahviour of `six.text_type`.

Whilst making the edit I noticed that `yubicommon.compat.string_types` was incorrect. As implied by the name `six.string_types` is a sequence of types - specifically a tuple

```
$ python2 -c 'import six; print(six.string_types)'
(<type 'basestring'>,)
$ python3 -c 'import six; print(six.string_types)'
(<class 'str'>,)
```

This doesn't make much of a difference for the common use case: `isinstance(foo, bar)` is equivalent to `isinstance(foo, (bar,))`. But if we're going to reimplement parts of `six`, let's be consistent.
