### PR TITLE
Hide on OS X should not break dock icon

### DIFF
--- a/yubicommon/qt/classes.py
+++ b/yubicommon/qt/classes.py
@@ -31,8 +31,8 @@ from .worker import Worker
 import os
 import sys
 import importlib
-
 from .. import compat
+from .osx import osx_hide
 
 __all__ = ['Application', 'Dialog', 'MutexLocker']
 
@@ -74,8 +74,13 @@ class _MainWindow(QtGui.QMainWindow):
 
     def __init__(self):
         super(_MainWindow, self).__init__()
-
         self._widget = None
+
+    def hide(self):
+        if sys.platform == 'darwin':
+            osx_hide()
+        else:
+            super(_MainWindow, self).hide()
 
     def customEvent(self, event):
         event.callback()

--- a/yubicommon/qt/osx.py
+++ b/yubicommon/qt/osx.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2014 Yubico AB
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permission under GNU GPL version 3 section 7
+#
+# If you modify this program, or any covered work, by linking or
+# combining it with the OpenSSL project's OpenSSL library (or a
+# modified version of that library), containing parts covered by the
+# terms of the OpenSSL or SSLeay licenses, We grant you additional
+# permission to convey the resulting work. Corresponding Source for a
+# non-source form of such a combination shall include the source code
+# for the parts of OpenSSL used as well as that of the covered work.
+
+import ctypes
+from ..ctypes import load_library
+
+class ProcessSerialNumber(ctypes.Structure):
+    _fields_ = [('highLongOfPsn', ctypes.c_uint32),
+                ('lowLongOfPSN', ctypes.c_uint32)]
+
+
+def osx_hide():
+
+    """ Hide the window and let the dock
+    icon be able to show the window again. """
+
+    app_services = load_library('ApplicationServices')
+    show_hide_proc = app_services.ShowHideProcess
+    show_hide_proc.argtypes = [ctypes.POINTER(ProcessSerialNumber),
+                            ctypes.c_bool]
+
+    psn = ProcessSerialNumber()
+    app_services.GetFrontProcess(ctypes.byref(psn))
+    show_hide_proc(ctypes.byref(psn), False)


### PR DESCRIPTION
When hiding a Qt application on OS X a call to ShowHideProcess
is done in order to let the dock icon bring back the window.

Closes Yubico/yubioath-desktop#46
