### PR TITLE
Fix byte2int for array multiple indices

### DIFF
--- a/yubicommon/compat.py
+++ b/yubicommon/compat.py
@@ -36,6 +36,6 @@ def int2byte(i):
 
 
 def byte2int(i):
-    if _PY2:
-        return ord(i)
-    return i
+    if isinstance(i, int):
+        return i
+    return ord(i)


### PR DESCRIPTION
```
# py -3
>>> t
b'test'
>>> t[0]
116
>>> t[0:1]
b't'
>>> byte2int(t[0:1])
b't'
```
-> byte2int isn't working when extracting from "array" using 2 indices.
So let's simply check if it's already an int or not.